### PR TITLE
Fixed: collapse-uncollapse issue in english events

### DIFF
--- a/docs/js/events.js
+++ b/docs/js/events.js
@@ -14,6 +14,10 @@ let MyEvents = {
     events.forEach(function(e) {
       that.addEvent(e);
     });
+    // Hidden template and visible area had same collbase body target id.
+    // Deleted hidden template event to render only one collapse
+    // Body target id for the event in a page.
+    $('.template-event').remove();
   },
   addEventsNone: function(events) {
     this.addToVisibleArea('template-no-events');

--- a/docs/js/events.js
+++ b/docs/js/events.js
@@ -14,9 +14,9 @@ let MyEvents = {
     events.forEach(function(e) {
       that.addEvent(e);
     });
-    // Hidden template and visible area had same collbase body target id.
+    // Hidden template and visible area had same collapse body target id.
     // Deleted hidden template event to render only one collapse
-    // Body target id for the event in a page.
+    // Body target id for each event in a page.
     $('.template-event').remove();
   },
   addEventsNone: function(events) {


### PR DESCRIPTION
  Hidden template and visible area had same collapse body target id. Deleted hidden template event to render only one collapse body target id for the event in a page.
